### PR TITLE
Reverte "fix: removes global variable in get_next_line (#9)"

### DIFF
--- a/libft/libft/ft_io/get_next_line.h
+++ b/libft/libft/ft_io/get_next_line.h
@@ -25,6 +25,8 @@ enum e_gnlstatus
 	GNLEOF,
 };
 
+void	gnl_clear(void);
+
 char	*get_next_line(int fd);
 
 #endif

--- a/src/map_config.c
+++ b/src/map_config.c
@@ -79,6 +79,7 @@ t_err	load_map_config(const char *filename, t_config *config)
 	else
 		err = error_from("error while loading map configuration",
 				strerror(errno));
+	gnl_clear();
 	close(fd);
 	return (err);
 }


### PR DESCRIPTION
Esse PR reverte o commit 341fd3773672f44d39d1cefacbd374d29e218c34 por causa de
um erro em `get_next_line`.

Vou abrir uma issue para que resolvamos futuramente o uso da variável global.
