### PR TITLE
Remove variável global e leaks de memória do get_next_line

### DIFF
--- a/libft/libft/ft_io/get_next_line.c
+++ b/libft/libft/ft_io/get_next_line.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/05/29 16:56:03 by vgoncalv          #+#    #+#             */
-/*   Updated: 2023/02/01 20:16:39 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2023/02/01 20:17:56 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,7 +89,11 @@ char	*get_next_line(int fd)
 	{
 		status = read_chunk(fd, &(saves[fd]));
 		if (status == GNLERROR)
+		{
+			free(saves[fd]);
+			saves[fd] = NULL;
 			return (NULL);
+		}
 		if (status == GNLEOF)
 			break ;
 	}

--- a/libft/libft/ft_io/get_next_line.h
+++ b/libft/libft/ft_io/get_next_line.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_next_line.h                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vgoncalv <vgoncalv>                        +#+  +:+       +#+        */
+/*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/04 15:58:41 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/09/04 16:05:00 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2023/01/20 12:03:36 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,6 @@ enum e_gnlstatus
 	GNLERROR = 1,
 	GNLEOF,
 };
-
-void	gnl_clear(void);
 
 char	*get_next_line(int fd);
 

--- a/src/config/load_config.c
+++ b/src/config/load_config.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/15 12:41:59 by vgoncalv          #+#    #+#             */
-/*   Updated: 2023/01/18 08:53:03 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2023/02/01 20:17:17 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,7 +90,6 @@ int	load_config(const char *filename, t_config *config)
 		close(fd);
 		return (1);
 	}
-	gnl_clear();
 	close(fd);
 	return (0);
 }


### PR DESCRIPTION
# Mudanças
- Remove uma variável "global" (ao arquivo) que achamos ser contra a norma
- Conserta memory leak do `get_next_line`

> Esperando #12 ser mergeado na main
